### PR TITLE
Add handling of a <font> tag

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -189,7 +189,8 @@ func GetDateID(date time.Time) uint64 {
 // RemoveUnsupportedTags shortcut for removing all unsopurted tags and returns fixed string
 func RemoveUnsupportedTags(source string) string {
 	source = RemoveSimpleUnsupportedTags(source)
-	return ReplaceComplexOpenTags(source, "span", "")
+	source = ReplaceComplexOpenTags(source, "span", "")
+	return ReplaceComplexOpenTags(source, "font", "")
 }
 
 // RemoveSimpleUnsupportedTags remove from string all simple tags unsupported by Telegram and returns fixed string
@@ -214,6 +215,7 @@ func RemoveSimpleUnsupportedTags(source string) string {
 		"</sub>":  ")",
 		"<li>":    " — ",
 		"</span>": "",
+		"</font>": "",
 	}
 	for pattern, replacement := range tagsToReplacement {
 		source = strings.ReplaceAll(source, pattern, replacement)


### PR DESCRIPTION
The task for 15 March broke sending, because of limited tags support on Telegram side. Added `<font>` removing.